### PR TITLE
fix: update minimum supported version of Terraform to v1.13

### DIFF
--- a/.changes/unreleased/foundry_basic-fixed-20250825-151512.yaml
+++ b/.changes/unreleased/foundry_basic-fixed-20250825-151512.yaml
@@ -1,0 +1,7 @@
+project: foundry_basic
+kind: fixed
+body: Adjusted Minimum Supported Version of Terraform to v1.13
+time: 2025-08-25T15:15:12.076906-07:00
+custom:
+    Author: timfpark
+    Issue: "26"

--- a/.changes/unreleased/foundry_basic_private-fixed-20250825-151512.yaml
+++ b/.changes/unreleased/foundry_basic_private-fixed-20250825-151512.yaml
@@ -1,0 +1,7 @@
+project: foundry_basic_private
+kind: fixed
+body: Adjusted Minimum Supported Version of Terraform to v1.13
+time: 2025-08-25T15:15:12.076938-07:00
+custom:
+    Author: timfpark
+    Issue: "26"

--- a/.changes/unreleased/foundry_standard-fixed-20250825-151512.yaml
+++ b/.changes/unreleased/foundry_standard-fixed-20250825-151512.yaml
@@ -1,0 +1,7 @@
+project: foundry_standard
+kind: fixed
+body: Adjusted Minimum Supported Version of Terraform to v1.13
+time: 2025-08-25T15:15:12.076939-07:00
+custom:
+    Author: timfpark
+    Issue: "26"

--- a/modules/ai_foundry/agent_capability_host_connections.role_assignments.tf
+++ b/modules/ai_foundry/agent_capability_host_connections.role_assignments.tf
@@ -1,7 +1,7 @@
 # Required role assignments for the resources to be used as Agent connections
 
 resource "azurerm_role_assignment" "cosmosdb_operator_ai_foundry_project" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     resource.time_sleep.wait_project_identities
@@ -13,7 +13,7 @@ resource "azurerm_role_assignment" "cosmosdb_operator_ai_foundry_project" {
 }
 
 resource "azurerm_role_assignment" "storage_blob_data_contributor_ai_foundry_project" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     resource.time_sleep.wait_project_identities
@@ -25,7 +25,7 @@ resource "azurerm_role_assignment" "storage_blob_data_contributor_ai_foundry_pro
 }
 
 resource "azurerm_role_assignment" "search_index_data_contributor_ai_foundry_project" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     resource.time_sleep.wait_project_identities
@@ -37,7 +37,7 @@ resource "azurerm_role_assignment" "search_index_data_contributor_ai_foundry_pro
 }
 
 resource "azurerm_role_assignment" "search_service_contributor_ai_foundry_project" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     resource.time_sleep.wait_project_identities
@@ -53,7 +53,7 @@ resource "azurerm_role_assignment" "search_service_contributor_ai_foundry_projec
 ## Pause 60 seconds to allow for role assignments to propagate
 ##
 resource "time_sleep" "wait_rbac" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     azurerm_role_assignment.cosmosdb_operator_ai_foundry_project[0],
@@ -74,7 +74,7 @@ locals {
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_user_thread_message_store" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     azapi_resource.ai_foundry_project_capability_host
@@ -88,7 +88,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_user_
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_system_thread_name" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     azurerm_cosmosdb_sql_role_assignment.cosmosdb_db_sql_role_aifp_user_thread_message_store
@@ -102,7 +102,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_syste
 }
 
 resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_entity_store_name" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     azurerm_cosmosdb_sql_role_assignment.cosmosdb_db_sql_role_aifp_system_thread_name
@@ -118,7 +118,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "cosmosdb_db_sql_role_aifp_entit
 ## Create the necessary data plane role assignments to the Azure Storage Account containers created by the AI Foundry Project
 ##
 resource "azurerm_role_assignment" "storage_blob_data_owner_ai_foundry_project" {
-  count = var.agent_capability_host_connections != null && var.agent_capability_host_connections.create_required_role_assignments ? 1 : 0
+  count = var.agent_capability_host_connections != null && try(var.agent_capability_host_connections.create_required_role_assignments, false) ? 1 : 0
 
   depends_on = [
     azapi_resource.ai_foundry_project_capability_host

--- a/reference_architectures/foundry_basic/README.md
+++ b/reference_architectures/foundry_basic/README.md
@@ -75,7 +75,7 @@ The Basic AI Foundry configuration creates a minimal but complete AI development
 
 1. Azure CLI installed and configured on your local workstation or deployment pipeline server
 
-1. Terraform CLI version v1.10 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
+1. Terraform CLI version v1.13 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
 
 ### Basic Deployment
 

--- a/reference_architectures/foundry_basic_private/README.md
+++ b/reference_architectures/foundry_basic_private/README.md
@@ -77,7 +77,7 @@ The Basic AI Foundry configuration creates a minimal but complete AI development
 
 1. Azure CLI installed and configured on your local workstation or deployment pipeline server
 
-1. Terraform CLI version v1.10 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
+1. Terraform CLI version v1.13 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
 
 1. An existing virtual network (VNet) in your Azure subscription with a subnet that includes the following private DNS Zones, created in the same resource group as the VNet:
 

--- a/reference_architectures/foundry_standard/README.md
+++ b/reference_architectures/foundry_standard/README.md
@@ -77,7 +77,7 @@ Note: The architecture diagram is similar in shape to the basic configuration wi
 
 1. Azure CLI installed and configured on your local workstation or deployment pipeline server
 
-1. Terraform CLI version v1.10 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
+1. Terraform CLI version v1.13 or later on your local workstation or deployment pipeline server. This template requires the usage of both the AzureRm and AzApi Terraform providers.
 
 ### Standard Deploy
 


### PR DESCRIPTION
# 📥 Pull Request

## 🔗 Related Issue(s)

Close #26 

## ❓ What are you trying to address

- CAIRA did not work on Terraform v1.10, a supported version per the docs.

## ✨ Description of new changes

- Update minimum supported Terraform version to v1.13 in documentation.
- Add try() calls to provide reasonable defaults for calls that failed in bug report.

## ☑️ Checklist

- [X] 🔍 I have performed a self-review of my own code.
- [X] 📝 I have commented my code, particularly in hard-to-understand areas.
- [X] 🧹 I have run the linter and fixed any issues (if applicable).
- [X] 📄 I have updated the documentation to reflect my changes (if necessary).
