### PR TITLE
ci(pr_changelog): update pull request handling on forks

### DIFF
--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -3,7 +3,7 @@
 name: 🔄 Changelog
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
 concurrency:
@@ -18,7 +18,7 @@ permissions:
 jobs:
   check_changelog:
     name: 🔄 Check Changelog
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'state/skip-changelog') && github.actor != 'dependabot[bot]' }}
+    if: ${{ (!contains(github.event.pull_request_target.labels.*.name, 'state/skip-changelog') || !contains(github.event.pull_request.labels.*.name, 'state/skip-changelog')) && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-24.04
     steps:
       - name: ⤵️ Checkout
@@ -46,7 +46,7 @@ jobs:
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request_target.number || github.event.pull_request.number }}
           comment-author: github-actions[bot]
           body-includes: "<!-- changelog -->"
 
@@ -62,7 +62,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         if: steps.filter.outputs.exists == 'false' && steps.fc.outputs.comment-id == ''
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request_target.number || github.event.pull_request.number }}
           body-path: changie.md
 
       - name: 📝 Update comment
@@ -105,7 +105,7 @@ jobs:
 
   skip_changelog:
     name: 🔄 Check Changelog
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'state/skip-changelog') || github.actor == 'dependabot[bot]' }}
+    if: ${{ contains(github.event.pull_request_target.labels.*.name, 'state/skip-changelog') || contains(github.event.pull_request.labels.*.name, 'state/skip-changelog') || github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-24.04
     steps:
       - name: 🔎 Find comment
@@ -113,7 +113,7 @@ jobs:
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request_target.number || github.event.pull_request.number }}
           comment-author: github-actions[bot]
           body-includes: "<!-- changelog -->"
 


### PR DESCRIPTION
# 📥 Pull Request

## 🔗 Related Issue(s)

Close #37

## ❓ What are you trying to address

This pull request updates the `.github/workflows/pr_changelog.yml` workflow to improve compatibility with `pull_request_target` events and ensure changelog automation works correctly for both regular and target-based pull requests.

## ✨ Description of new changes

- The workflow trigger was changed from `pull_request` to `pull_request_target` to allow the workflow to run with elevated permissions and access to the base repository, which is important for automated changelog management.

## ☑️ Checklist

- [x] 🔍 I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🧹 I have run the linter and fixed any issues (if applicable).
- [ ] 📄 I have updated the documentation to reflect my changes (if necessary).
