### PR TITLE
fix(terraform): update location in integration tests for foundry basic private configuration

### DIFF
--- a/reference_architectures/foundry_basic_private/tests/integration/test.tftest.hcl
+++ b/reference_architectures/foundry_basic_private/tests/integration/test.tftest.hcl
@@ -22,7 +22,7 @@ run "testint_foundry_basic_private_comprehensive" {
   command = apply
 
   variables {
-    location             = "eastus2" # Match the setup module location
+    location             = "swedencentral"
     foundry_subnet_id    = run.setup.connection.id
     project_name         = "integration-test-private-project"
     project_display_name = "Integration Test Private Project"
@@ -49,7 +49,7 @@ run "testint_foundry_basic_private_comprehensive" {
   }
 
   assert {
-    condition     = azurerm_resource_group.this[0].location == "eastus2"
+    condition     = azurerm_resource_group.this[0].location == "swedencentral"
     error_message = "Resource group location should match the specified location"
   }
 
@@ -281,7 +281,7 @@ run "testint_foundry_basic_private_comprehensive" {
 
   # Verify configured variables are properly applied
   assert {
-    condition     = var.location == "eastus2"
+    condition     = var.location == "swedencentral"
     error_message = "Location variable should be properly applied"
   }
 


### PR DESCRIPTION
# 📥 Pull Request

## 🔗 Related Issue(s)

Close #110 

## ❓ What are you trying to address

- Address test execution error for foundry_basic_private

## ✨ Description of new changes

Set created resources to the same location in which the setup creates the networking resources required to run the tests.

## ☑️ Checklist

- [x] 🔍 I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🧹 I have run the linter and fixed any issues (if applicable).
- [x] 📄 I have updated the documentation to reflect my changes (if necessary).
