### PR TITLE
fix(scripts): exclude infrastructure pools from path validation output

### DIFF
--- a/.github/scripts/tf_dirs.mjs
+++ b/.github/scripts/tf_dirs.mjs
@@ -88,8 +88,8 @@ export default async ({ context, core }) => {
           dirPath = dirPath.substring(0, testsIndex);
         }
 
-        // Validate and normalize the path, but exclude module paths from final output
-        if (dirPath && dirPath !== '.' && dirPath.length > 0 && !dirPath.includes('modules')) {
+        // Validate and normalize the path, but exclude module paths and infrastructure pools from final output
+        if (dirPath && dirPath !== '.' && dirPath.length > 0 && !dirPath.includes('modules') && !dirPath.includes('testing/infrastructure_pools')) {
           dirPaths.add(dirPath);
         }
       } catch (error) {


### PR DESCRIPTION
# 📥 Pull Request

## 🔗 Related Issue(s)

Close #213 

## ❓ What are you trying to address

Matrix build identifies infrastructure pools folders as test candidates

## ✨ Description of new changes

infrastructure pool folders are excluded from the matrix build

## ☑️ Checklist

- [ ] 🔍 I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🧹 I have run the linter and fixed any issues (if applicable).
- [ ] 📄 I have updated the documentation to reflect my changes (if necessary).
