### PR TITLE
project/role_assignments: allow creation of more container prefixes

### DIFF
--- a/modules/ai_foundry_project/agent_capability_host_connections.role_assignments.tf
+++ b/modules/ai_foundry_project/agent_capability_host_connections.role_assignments.tf
@@ -115,6 +115,8 @@ resource "azurerm_role_assignment" "storage_blob_data_owner_ai_foundry_project" 
     OR
     (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringStartsWithIgnoreCase '${local.project_id_guid}'
     AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringLikeIgnoreCase '*-azureml-agent')
+    OR
+    (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringStartsWithIgnoreCase '${local.resource_group_name}-cog-x-')
   )
   EOT
 }

--- a/modules/ai_foundry_project/main.tf
+++ b/modules/ai_foundry_project/main.tf
@@ -1,5 +1,6 @@
 locals {
-  resource_group_id = provider::azapi::parse_resource_id("Microsoft.CognitiveServices/accounts", var.ai_foundry_id).parent_id
+  resource_group_id   = provider::azapi::parse_resource_id("Microsoft.CognitiveServices/accounts", var.ai_foundry_id).parent_id
+  resource_group_name = provider::azapi::parse_resource_id("Microsoft.Resources/resourceGroups", local.resource_group_id).resource_group_name
 }
 
 resource "azapi_resource" "ai_foundry_project" {


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

When using the Foundry portal to add agent knowledge from local files, a storage container is created. This has the pattern `rg_name-cog-x-random_guid`

<img width="1360" height="373" alt="image" src="https://github.com/user-attachments/assets/9cf0b11e-25b0-427a-b974-d1cb7138c474" />

## ✨ Description of new changes

Allow the project MSI to create blob containers with the pattern `rg_name-cog-x-random_guid` in order to upload local files to the agent's knowledge.


## ☑️ Checklist

- [ ] 🔍 I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🧹 I have run the linter and fixed any issues (if applicable).
- [ ] 📄 I have updated the documentation to reflect my changes (if necessary).
