### PR TITLE
update foundry avm to 0.11.2

### DIFF
--- a/reference-architectures/iac/foundry/main.tf
+++ b/reference-architectures/iac/foundry/main.tf
@@ -118,7 +118,7 @@ resource "azapi_resource" "appinsights_connection" {
 resource "azapi_resource_action" "purge_ai_foundry" {
   method      = "DELETE"
   resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${var.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/aif-${local.base_name}"
-  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2025-09-01"
+  type        = "Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01"
   when        = "destroy"
 }
 

--- a/reference-architectures/iac/foundry/main.tf
+++ b/reference-architectures/iac/foundry/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_application_insights" "this" {
 
 module "foundry" {
   source  = "Azure/avm-ptn-aiml-ai-foundry/azurerm"
-  version = "0.10.1"
+  version = "0.11.2"
 
   base_name                  = local.avm_base_name
   location                   = var.location


### PR DESCRIPTION
This pull request updates the `reference-architectures/iac/foundry/main.tf` file with improvements to module versioning and resource type specification. The main changes are focused on keeping dependencies up to date and correcting resource type identifiers for Azure resources.

Dependency and resource updates:

* Updated the `foundry` module version from `0.10.1` to `0.11.2` to ensure the latest features and bug fixes are included.
* Corrected the `type` field for the `azapi_resource_action.purge_ai_foundry` resource to use the proper Azure resource type identifier (`Microsoft.CognitiveServices/locations/resourceGroups/deletedAccounts@2025-09-01`) instead of the previous incorrect value.