### PR TITLE
chore: bump caira skill version to 0.4.2

### DIFF
--- a/skills/caira/SKILL.md
+++ b/skills/caira/SKILL.md
@@ -4,7 +4,7 @@ description: Primary entrypoint for coding agents using CAIRA as reference mater
 compatibility: Needs access to the github.com/microsoft/caira repository.
 metadata:
   author: Microsoft
-  version: "0.4.1"
+  version: "0.4.2"
 ---
 
 # CAIRA


### PR DESCRIPTION
This pull request makes a minor update to the `skills/caira/SKILL.md` file, incrementing the skill version from "0.4.1" to "0.4.2".