### PR TITLE
Minor adjustment to skill guidance

### DIFF
--- a/skills/caira/SKILL.md
+++ b/skills/caira/SKILL.md
@@ -4,7 +4,7 @@ description: Primary entrypoint for coding agents using CAIRA as reference mater
 compatibility: Needs access to the github.com/microsoft/caira repository.
 metadata:
   author: Microsoft
-  version: "0.4.2"
+  version: "0.4.3"
 ---
 
 # CAIRA
@@ -24,10 +24,13 @@ Ask only what is needed to choose components:
 ## Core rules
 
 - Use the `reference-architectures` directory in the `github.com/microsoft/caira/` repository as the canonical source of truth. Inspect it either with the github mcp server if available, through GitHub raw URLs or clone the repository temporarily to inspect `reference-architectures/` locally;
+- When reviewing the reference architectures, read the full code of the desired conponent. do not limit the investigation to the readme or docs. The source of truth is the code.  
 - Prefer small component references over full-stack copying.
 - For scenarios that need OpenAI-compatible endpoints, prefer the Foundry IaC reference unless the user already has endpoints or asks for a different approach.
 - Determine what the user already has before proposing new infrastructure.
-- When possible, prefer managed identities or other passwordless identity patterns over API keys, static credentials, or secrets, unless the user explicitly asks for an API-key- or secret-based approach.
+- Always use managed identities or other passwordless identity patterns. NEVER USE API keys, static credentials, or secrets, unless the user explicitly asks for an API-key- or secret-based approach.
+- When implementing IaC for Foundry, use the Azure Verified Module, as shown in the reference architectures. Don't use stand alone terraform resources related to Foundry unless explicitly requested.
+- If an API that communicates with Foundry needs to be implemented, ALWAYS prefer using Foundry resources instead of Azure OpenAI, unless the user explicitly asks for it. Even with the OpenAI Agents SDK.
 - Before proposing repository security scans, check whether the target repository already uses or has configured Gitleaks, Trivy, or similar tools for secret, dependency, container, or IaC scanning. If similar scanning is missing, ask whether the user wants to add Gitleaks and/or Trivy scans before implementing them.
 - Keep recommendations focused on the current reference components listed below.
 - Explain which CAIRA paths influenced the recommendation or generated files.

--- a/skills/caira/SKILL.md
+++ b/skills/caira/SKILL.md
@@ -29,8 +29,8 @@ Ask only what is needed to choose components:
 - For scenarios that need OpenAI-compatible endpoints, prefer the Foundry IaC reference unless the user already has endpoints or asks for a different approach.
 - Determine what the user already has before proposing new infrastructure.
 - Always use managed identities or other passwordless identity patterns. NEVER USE API keys, static credentials, or secrets, unless the user explicitly asks for an API-key- or secret-based approach.
-- When implementing IaC for Foundry, use the Azure Verified Module, as shown in the reference architectures. Don't use stand alone terraform resources related to Foundry unless explicitly requested.
-- If an API that communicates with Foundry needs to be implemented, ALWAYS prefer using Foundry resources instead of Azure OpenAI, unless the user explicitly asks for it. Even with the OpenAI Agents SDK.
+- When implementing IaC for Foundry, use the Azure Verified Module, as shown in the reference architectures. Don't use standalone Terraform resources related to Foundry unless explicitly requested.
+- If an API that communicates with Foundry needs to be implemented, ALWAYS prefer using Foundry resources instead of Azure OpenAI resources, unless the user explicitly asks for Azure OpenAI. Even with the OpenAI Agents SDK.
 - Before proposing repository security scans, check whether the target repository already uses or has configured Gitleaks, Trivy, or similar tools for secret, dependency, container, or IaC scanning. If similar scanning is missing, ask whether the user wants to add Gitleaks and/or Trivy scans before implementing them.
 - Keep recommendations focused on the current reference components listed below.
 - Explain which CAIRA paths influenced the recommendation or generated files.

--- a/skills/caira/SKILL.md
+++ b/skills/caira/SKILL.md
@@ -23,8 +23,8 @@ Ask only what is needed to choose components:
 
 ## Core rules
 
-- Use the `reference-architectures` directory in the `github.com/microsoft/caira/` repository as the canonical source of truth. Inspect it either with the github mcp server if available, through GitHub raw URLs or clone the repository temporarily to inspect `reference-architectures/` locally;
-- When reviewing the reference architectures, read the full code of the desired conponent. do not limit the investigation to the readme or docs. The source of truth is the code.  
+- Use the `reference-architectures` directory in the `github.com/microsoft/caira/` repository as the canonical source of truth. Inspect it either with the GitHub MCP server if available, through GitHub raw URLs, or clone the repository temporarily to inspect `reference-architectures/` locally.
+- When reviewing the reference architectures, read the full code of the desired component. Do not limit the investigation to the README or docs. The source of truth is the code.
 - Prefer small component references over full-stack copying.
 - For scenarios that need OpenAI-compatible endpoints, prefer the Foundry IaC reference unless the user already has endpoints or asks for a different approach.
 - Determine what the user already has before proposing new infrastructure.


### PR DESCRIPTION
This pull request updates the documentation for the CAIRA skill, clarifying and strengthening the rules for referencing and implementing infrastructure components. The changes focus on enforcing best practices for security, component usage, and reference architecture adherence.

Key documentation updates:

**Security and Identity Management:**
* Updated guidance to always use managed identities or passwordless patterns, and to never use API keys, static credentials, or secrets unless explicitly requested by the user.

**Reference Architecture Usage:**
* Added instruction to read the full code of desired components in `reference-architectures` rather than relying on README or docs, emphasizing that the code is the source of truth.
* Specified that when implementing IaC for Foundry, the Azure Verified Module from the reference architectures should always be used; standalone Terraform resources for Foundry should be avoided unless explicitly requested.
* Stated that APIs communicating with Foundry must use Foundry resources instead of Azure OpenAI, unless the user asks otherwise, even when using the OpenAI Agents SDK.

**Version Update:**
* Incremented the skill version from 0.4.2 to 0.4.3.